### PR TITLE
Update dbt-core to 1.2.5 to fix "No module named pytz" error

### DIFF
--- a/dbt/common.sh
+++ b/dbt/common.sh
@@ -16,7 +16,7 @@ DBT_WITH=postgres
 # ^^ will install all adapters excluding mssql 
 ########################################
 
-dbt_postgres_ref=dbt-core@v1.2.1 # postgres adapter is part of core now
+dbt_postgres_ref=dbt-core@v1.2.5 # postgres adapter is part of core now
 dbt_redshift_ref=dbt-redshift@v1.2.1
 dbt_bigquery_ref=dbt-bigquery@v1.2.0
 dbt_snowflake_ref=dbt-snowflake@v1.2.0


### PR DESCRIPTION
When installing dbt with all default options using the command `vagrant up --provision-with basetools,docsify,docker,postgresql,dbt`, I received the error "hashiqube0.service.consul: ModuleNotFoundError: No module named 'pytz'".

Upon investigating and researching online, I found that dbt-core had this bug, which they fixed recently. So, I fixed the code to install the minor bugfixed version of dbt-core. Hope it helps other users of hashiqube as well. Thanks!

**Check dbt-core v1.2.5:** https://github.com/dbt-labs/dbt-core/releases/tag/v1.2.5